### PR TITLE
[BW-1209] Auto update cromwell-helm chart upon merge to 'main'

### DIFF
--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -38,9 +38,10 @@ jobs:
         env:
           BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         run: |
+          git checkout -b auto-chart--version-update-$NEXT_VERSION
           git diff
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"
           git commit -am "Auto update to cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git ss_auto_update_chart_version
+          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto-chart--version-update-$NEXT_VERSION
 

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -35,7 +35,6 @@ jobs:
           helm package cromwell-helm/
           mv cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
-
       - name: Push changes to GitHub
         env:
           BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -37,11 +37,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
-#          git checkout main
           git checkout -b auto-chart-version-update-$NEXT_VERSION
           git diff
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"
-          #git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
           git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto-chart-version-update-$NEXT_VERSION

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.ref }}
 
       - name: Find out next chart version
         run: |
@@ -35,11 +33,11 @@ jobs:
           helm package cromwell-helm/
           mv cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
+
       - name: Push changes to GitHub
         env:
           BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         run: |
-#          git checkout ss_auto_update_chart_version
           git diff
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           currentVersion=$(grep 'version:' cromwell-helm/Chart.yaml | awk '{print $NF}')
 
-          # this will increment only the last version digit. For example, it will update 0.1.10 => 0.1.11
+          # this will increment only the patch version digit. For example, it will update 0.1.10 => 0.1.11
           nextVersion=$(echo ${currentVersion} | awk -F. -v OFS=. '{$NF += 1 ; print}')
 
           echo "CURRENT_VERSION=$currentVersion" >> $GITHUB_ENV

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'ss_auto_update_chart_version' # for testing purposes. Remove later
 
 jobs:
   update-and-publish:
@@ -37,9 +36,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
-          git checkout -b auto-chart-version-update-$NEXT_VERSION
+          git checkout main
           git diff
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto-chart-version-update-$NEXT_VERSION
+          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'ss_auto_update_chart_version' # for testing purposes. Remove later
 
 jobs:
   update-and-publish:
@@ -43,4 +42,3 @@ jobs:
           git config --global user.email "broadbot@broadinstitute.org"
           git commit -am "Auto update to cromwell-helm chart version to $NEXT_VERSION"
           git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto-chart-version-update-$NEXT_VERSION
-

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/replace
         with:
           files: cromwell-helm/Chart.yaml
-          replacements: '${{ CURRENT_VERSION }}=${{ NEXT_VERSION }}'
+          replacements: '$CURRENT_VERSION=$NEXT_VERSION'
 
       # OR
 

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -22,7 +22,7 @@ jobs:
           nextVersion=$(echo ${currentVersion} | awk -F. -v OFS=. '{$NF += 1 ; print}')
 
           echo "CURRENT_VERSION=$currentVersion" >> $GITHUB_ENV
-          echo "NEXT_VERSION=nextVersion" >> $GITHUB_ENV
+          echo "NEXT_VERSION=$nextVersion" >> $GITHUB_ENV
 
 #      - name: Update chart.yaml file with new chart version
 #        uses: ./.github/actions/replace

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -38,7 +38,6 @@ jobs:
         env:
           BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         run: |
-          cd cromwhelm
           git checkout ss_auto_update_chart_version
           git diff
           git config --global user.name "broadbot"

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2
         with:
-          ref: ss_auto_update_chart_version
+          ref: ${{ github.ref }}
 
       - name: Find out next chart version
         run: |

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -1,0 +1,40 @@
+name: update-and-publish-cromwell-helm-chart
+on: pull_request
+#  pull_request:
+#    types:
+#      - closed
+
+jobs:
+  update-and-publish:
+    name: Updates and publishes new cromwell-helm chart
+    # only run this action when a PR is merged (and not on "closed")
+#    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Find out next chart version
+      - run: |
+          currentVersion=$(grep 'version:' cromwell-helm/Chart.yaml | awk '{print $NF}')
+
+          # this will increment only the last version digit. For example, it will update 0.1.10 => 0.1.11
+          nextVersion=$(echo ${currentVersion} | awk -F. -v OFS=. '{$NF += 1 ; print}')
+
+#      - name: Update chart.yaml file with new chart version
+#        uses: ./.github/actions/replace
+#        with:
+#          files: cromwell-helm/Chart.yaml
+#          replacements: '${{ currentVersion }}=${{ nextVersion }}'
+
+      # OR
+
+      - name: Update chart.yaml file with new chart version
+      - run: |
+          sed -i "s/$currentVersion/$nextVersion/" cromwell-helm/Chart.yaml
+
+      - name: Publish the new chart
+      - run: |
+          helm package cromwell-helm/
+          mv cromwell-${nextVersion}.tgz charts/cromwell-${nextVersion}.tgz
+          helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Find out next chart version
-      - run: |
+        run: |
           currentVersion=$(grep 'version:' cromwell-helm/Chart.yaml | awk '{print $NF}')
 
           # this will increment only the last version digit. For example, it will update 0.1.10 => 0.1.11
@@ -30,11 +30,11 @@ jobs:
       # OR
 
       - name: Update chart.yaml file with new chart version
-      - run: |
+        run: |
           sed -i "s/$currentVersion/$nextVersion/" cromwell-helm/Chart.yaml
 
       - name: Publish the new chart
-      - run: |
+        run: |
           helm package cromwell-helm/
           mv cromwell-${nextVersion}.tgz charts/cromwell-${nextVersion}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -25,19 +25,24 @@ jobs:
           echo "NEXT_VERSION=$nextVersion" >> $GITHUB_ENV
 
       - name: Update chart.yaml file with new chart version
-        uses: ./.github/actions/replace
-        with:
-          files: cromwell-helm/Chart.yaml
-          replacements: '$CURRENT_VERSION=$NEXT_VERSION'
-
-      # OR
-
-#      - name: Update chart.yaml file with new chart version
-#        run: |
-#          sed -i "s/$CURRENT_VERSION/$NEXT_VERSION/" cromwell-helm/Chart.yaml
+        run: |
+          sed -i "s/$CURRENT_VERSION/$NEXT_VERSION/" cromwell-helm/Chart.yaml
 
       - name: Publish the new chart
         run: |
           helm package cromwell-helm/
           mv cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
+
+      - name: Push changes to GitHub
+        env:
+          BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        run: |
+          cd cromwhelm
+          git checkout ss_auto_update_chart_version
+          git diff
+          git config --global user.name "broadbot"
+          git config --global user.email "broadbot@broadinstitute.org"
+          git commit -am "Auto update to cromwell-helm chart version to $NEXT_VERSION"
+          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git ss_auto_update_chart_version
+

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'ss_auto_update_chart_version' # for testing purposes. Remove later
 
 jobs:
   update-and-publish:
@@ -34,11 +35,13 @@ jobs:
 
       - name: Push changes to GitHub
         env:
-          BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
-          git checkout main
+#          git checkout main
+          git checkout -b auto-chart-version-update-$NEXT_VERSION
           git diff
-          git config --global user.name "broadbot"
-          git config --global user.email "broadbot@broadinstitute.org"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+          #git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto-chart-version-update-$NEXT_VERSION

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -36,9 +36,9 @@ jobs:
         env:
           BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         run: |
-          git checkout -b auto-chart-version-update-$NEXT_VERSION
+          git checkout main
           git diff
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"
-          git commit -am "Auto update to cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto-chart-version-update-$NEXT_VERSION
+          git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"
+          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -1,5 +1,5 @@
 name: update-and-publish-cromwell-helm-chart
-on: pull_request
+on: [pull_request]
 #  pull_request:
 #    types:
 #      - closed

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -24,17 +24,17 @@ jobs:
           echo "CURRENT_VERSION=$currentVersion" >> $GITHUB_ENV
           echo "NEXT_VERSION=$nextVersion" >> $GITHUB_ENV
 
-#      - name: Update chart.yaml file with new chart version
-#        uses: ./.github/actions/replace
-#        with:
-#          files: cromwell-helm/Chart.yaml
-#          replacements: '${{ currentVersion }}=${{ nextVersion }}'
+      - name: Update chart.yaml file with new chart version
+        uses: ./.github/actions/replace
+        with:
+          files: cromwell-helm/Chart.yaml
+          replacements: '${{ CURRENT_VERSION }}=${{ NEXT_VERSION }}'
 
       # OR
 
-      - name: Update chart.yaml file with new chart version
-        run: |
-          sed -i "s/$CURRENT_VERSION/$NEXT_VERSION/" cromwell-helm/Chart.yaml
+#      - name: Update chart.yaml file with new chart version
+#        run: |
+#          sed -i "s/$CURRENT_VERSION/$NEXT_VERSION/" cromwell-helm/Chart.yaml
 
       - name: Publish the new chart
         run: |

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -1,14 +1,13 @@
 name: update-and-publish-cromwell-helm-chart
-on: [pull_request]
-#  pull_request:
-#    types:
-#      - closed
+on:
+  push:
+    branches:
+      - 'main'
+      - 'ss_auto_update_chart_version' # for testing purposes. Remove later
 
 jobs:
   update-and-publish:
-    name: Updates and publishes new cromwell-helm chart
-    # only run this action when a PR is merged (and not on "closed")
-#    if: github.event.pull_request.merged == true
+    name: Update and publish new cromwell-helm chart
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
@@ -24,11 +23,11 @@ jobs:
           echo "CURRENT_VERSION=$currentVersion" >> $GITHUB_ENV
           echo "NEXT_VERSION=$nextVersion" >> $GITHUB_ENV
 
-      - name: Update chart.yaml file with new chart version
+      - name: Bump chart version
         run: |
           sed -i "s/$CURRENT_VERSION/$NEXT_VERSION/" cromwell-helm/Chart.yaml
 
-      - name: Publish the new chart
+      - name: Publish the new helm chart and update index.yaml
         run: |
           helm package cromwell-helm/
           mv cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
@@ -38,10 +37,10 @@ jobs:
         env:
           BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         run: |
-          git checkout -b auto-chart--version-update-$NEXT_VERSION
+          git checkout -b auto-chart-version-update-$NEXT_VERSION
           git diff
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"
           git commit -am "Auto update to cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto-chart--version-update-$NEXT_VERSION
+          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto-chart-version-update-$NEXT_VERSION
 

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
+        with:
+          ref: ss_auto_update_chart_version
 
       - name: Find out next chart version
         run: |
@@ -38,7 +40,7 @@ jobs:
         env:
           BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         run: |
-          git checkout ss_auto_update_chart_version
+#          git checkout ss_auto_update_chart_version
           git diff
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -21,6 +21,9 @@ jobs:
           # this will increment only the last version digit. For example, it will update 0.1.10 => 0.1.11
           nextVersion=$(echo ${currentVersion} | awk -F. -v OFS=. '{$NF += 1 ; print}')
 
+          echo "CURRENT_VERSION=$currentVersion" >> $GITHUB_ENV
+          echo "NEXT_VERSION=nextVersion" >> $GITHUB_ENV
+
 #      - name: Update chart.yaml file with new chart version
 #        uses: ./.github/actions/replace
 #        with:
@@ -31,10 +34,10 @@ jobs:
 
       - name: Update chart.yaml file with new chart version
         run: |
-          sed -i "s/$currentVersion/$nextVersion/" cromwell-helm/Chart.yaml
+          sed -i "s/$CURRENT_VERSION/$NEXT_VERSION/" cromwell-helm/Chart.yaml
 
       - name: Publish the new chart
         run: |
           helm package cromwell-helm/
-          mv cromwell-${nextVersion}.tgz charts/cromwell-${nextVersion}.tgz
+          mv cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts


### PR DESCRIPTION
I tested it on my branch. Details:

- Github action [output #15](https://github.com/broadinstitute/cromwhelm/runs/6103872389?check_suite_focus=true) that updates chart version from 0.1.10 to 0.1.11 (this is because my branch didn't have latest changes from 'main' branch where the version number is 0.2.0)
- Updated `index.yaml` and chart version can be seen in [auto-chart-version-update-0.1.11 branch](https://github.com/broadinstitute/cromwhelm/compare/auto-chart-version-update-0.1.11) created during testing

Closes https://broadworkbench.atlassian.net/browse/BW-1209