### PR TITLE
Fix markdown issues in README [BT-618]

### DIFF
--- a/cromwell-helm/README.md
+++ b/cromwell-helm/README.md
@@ -5,14 +5,14 @@ Here is a suggested workflow for testing updates to this chart from local Termin
 1. Create a workspace in Leonardo and deploy a Cromwell usage via Swagger (https://leonardo-fiab.dsde-dev.broadinstitute.org:30443/#/apps/createApp)
 
 2. From a Terminal (not within the Leo VM… just on your local computer), do the following commands to set helm/kubectl to point to the right environment:
-   - gcloud auth login (Select your test.firecloud.org account)
-   - gcloud config set project <workspace project ID> (for example, terra-test-5dea92eb)
-   - gcloud container clusters get-credentials --zone=us-central1-a <cluster name> (for example, kecd4047-a970-4088-89dd-003288bcf6f1, see in Google Cloud console, to the right of the Cromwell service)
+   - `gcloud auth login` (Select your test.firecloud.org account)
+   - `gcloud config set project <workspace project ID>` (for example, terra-test-5dea92eb)
+   - `gcloud container clusters get-credentials --zone=us-central1-a <cluster name>` (for example, kecd4047-a970-4088-89dd-003288bcf6f1, see in Google Cloud console, to the right of the Cromwell service)
 
 3. Now you can edit the helm chart locally in your favorite editor. To update the instance of Cromwell running with your new chart:
-   - helm upgrade --namespace=<namepace> <release> cromwell-helm 
+   - `helm upgrade --namespace=<namepace> <release> cromwell-helm` 
    - Note: you can see the namespace in Google Cloud console to the right of the Cromwell service. Release is the same, with “ns” replaced by “rls”.
-     So for example: helm upgrade --namespace=jlfcsv-gxy-ns jlfcsv-gxy-rls cromwell-helm
+     So for example: `helm upgrade --namespace=jlfcsv-gxy-ns jlfcsv-gxy-rls cromwell-helm`
 
 **Rules for granting users permissions to run workflows (as the pet itself)**:
 - Add Workflow runner permissions against the project, then Service Account User permissions against ONLY the user’s pet SA:


### PR DESCRIPTION
Noticed while testing out #24. It turns out `<value>` doesn't display in markdown, so some of the documentation for live refreshing helm charts was not showing up