### PR TITLE
[BW-1209] Update auto publish chart workflow to add the newly created package chart 

### DIFF
--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -2,7 +2,7 @@ name: update-and-publish-cromwell-helm-chart
 on:
   push:
     branches:
-      - 'main'
+      - 'ss_fix_chart_location' # remove after testing
 
 jobs:
   update-and-publish:
@@ -29,17 +29,17 @@ jobs:
       - name: Publish the new helm chart and update index.yaml
         run: |
           helm package cromwell-helm/
-          mv cromwell-${NEXT_VERSION}.tgz charts
+          mv cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 
       - name: Push changes to GitHub
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
-          git checkout main
-          git add charts/cromwell-${NEXT_VERSION}.tgz
+          git checkout -b auto_update_chart_${NEXT_VERSION}
+          git add .
           git diff
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto_update_chart_${NEXT_VERSION}

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           helm package cromwell-helm/
           pwd
-          mv cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
+          mv $PWD/cromwell-${NEXT_VERSION}.tgz $PWD/charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 
       - name: Push changes to GitHub

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -40,6 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
           git checkout -b auto_update_chart_${NEXT_VERSION}
+          git add charts/cromwell-${NEXT_VERSION}.tgz
           git diff
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -28,8 +28,10 @@ jobs:
 
       - name: Publish the new helm chart and update index.yaml
         run: |
+          set -e
           helm package cromwell-helm/
           pwd
+          find charts
           mv $PWD/cromwell-${NEXT_VERSION}.tgz $PWD/charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -2,7 +2,7 @@ name: update-and-publish-cromwell-helm-chart
 on:
   push:
     branches:
-      - 'ss_fix_chart_location' # remove after testing
+      - 'main'
 
 jobs:
   update-and-publish:
@@ -36,10 +36,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
-          git checkout -b auto_update_chart_${NEXT_VERSION}
+          git checkout main
           git add charts/cromwell-${NEXT_VERSION}.tgz
           git diff
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto_update_chart_${NEXT_VERSION}
+          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -37,8 +37,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
           git checkout -b auto_update_chart_${NEXT_VERSION}
-          git add .
           git diff
+          git add .
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -31,7 +31,8 @@ jobs:
           set -e
           helm package cromwell-helm/
           pwd
-          mv $PWD/cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
+          mv $PWD/cromwell-${NEXT_VERSION}.tgz charts
+          find charts
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 
       - name: Push changes to GitHub

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -30,7 +30,6 @@ jobs:
         run: |
           helm package cromwell-helm/
           mv cromwell-${NEXT_VERSION}.tgz charts
-          find charts
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 
       - name: Push changes to GitHub

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -31,8 +31,7 @@ jobs:
           set -e
           helm package cromwell-helm/
           pwd
-          find charts
-          mv $PWD/cromwell-${NEXT_VERSION}.tgz $PWD/charts/cromwell-${NEXT_VERSION}.tgz
+          mv $PWD/cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 
       - name: Push changes to GitHub

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -2,7 +2,7 @@ name: update-and-publish-cromwell-helm-chart
 on:
   push:
     branches:
-      - 'main'
+      - 'ss_fix_chart_location' # remove after testing
 
 jobs:
   update-and-publish:
@@ -29,6 +29,7 @@ jobs:
       - name: Publish the new helm chart and update index.yaml
         run: |
           helm package cromwell-helm/
+          pwd
           mv cromwell-${NEXT_VERSION}.tgz charts/cromwell-${NEXT_VERSION}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 
@@ -36,9 +37,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
-          git checkout main
+          git checkout -b auto_update_chart_${NEXT_VERSION}
           git diff
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto_update_chart_${NEXT_VERSION}

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -28,10 +28,8 @@ jobs:
 
       - name: Publish the new helm chart and update index.yaml
         run: |
-          set -e
           helm package cromwell-helm/
-          pwd
-          mv $PWD/cromwell-${NEXT_VERSION}.tgz charts
+          mv cromwell-${NEXT_VERSION}.tgz charts
           find charts
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -2,7 +2,7 @@ name: update-and-publish-cromwell-helm-chart
 on:
   push:
     branches:
-      - 'ss_fix_chart_location' # remove after testing
+      - 'main'
 
 jobs:
   update-and-publish:
@@ -36,10 +36,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
-          git checkout -b auto_update_chart_${NEXT_VERSION}
+          git checkout main
           git diff
           git add .
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "Auto update cromwell-helm chart version to $NEXT_VERSION"
-          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git auto_update_chart_${NEXT_VERSION}
+          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main


### PR DESCRIPTION
The [Auto update cromwell-helm chart upon merge to 'main'](https://github.com/broadinstitute/cromwhelm/pull/23) missed out on adding the newly created packaged chart to the `charts/` folder. Not sure how I missed this but I had to explicitly to `git add charts/<new-chart>.tgz` to have it pushed to main. I tested out the changes in my branch and have the changes pushed to a new branch.

Previously:
- The auto update publish run after merging PR-23 pushed only the updated `index.yaml` and `chart.yaml`. [Commit here](https://github.com/broadinstitute/cromwhelm/commit/c2bae2e21214294affe7c4da3216130846f2f212).
- [GitHub workflow run logs](https://github.com/broadinstitute/cromwhelm/runs/6159672103?check_suite_focus=true) for above shows only 2 files changed
![Screen Shot 2022-04-25 at 12 00 47 PM](https://user-images.githubusercontent.com/16748522/165127857-3d16f632-6c66-4aea-8ce8-4a4c229b46ff.png)

Now:
- The [latest GitHub workflow run](https://github.com/broadinstitute/cromwhelm/runs/6160680060?check_suite_focus=true) shows 3 files changed and a create mode for `charts/cromwell-0.2.2.tgz`
![Screen Shot 2022-04-25 at 11 57 26 AM](https://user-images.githubusercontent.com/16748522/165127257-bc2937c0-d81d-4304-8517-bc8813681214.png)
- Newly created `cromwell-0.2.2.tgz` was pushed to the test branch [auto_update_chart_0.2.2](https://github.com/broadinstitute/cromwhelm/tree/auto_update_chart_0.2.2/charts)



Closes https://broadworkbench.atlassian.net/browse/BW-1209