### PR TITLE
BT-653 Add relay listener for Cromwell

### DIFF
--- a/coa-helm/templates/relay-listener-deployment.yaml
+++ b/coa-helm/templates/relay-listener-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: relaylistener
+  name: relaylistener
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: relaylistener
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.service: relaylistener
+    spec:
+      containers:
+        - name: relaylistener
+          image: {{ .Values.images.relaylistener }}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: LISTENER_RELAYCONNECTIONSTRING
+              value: {{ .Values.config.relayListenerConnectionString }}
+            - name: LISTENER_RELAYCONNECTIONNAME
+              value: {{ .Values.config.relayListenerConnectionName }}
+            - name: LISTENER_TARGETPROPERTIES_TARGETHOST
+              value: {{ .Values.config.relayListenerTargetHost }}
+            - name: LISTENER_TARGETPROPERTIES_REMOVEENTITYPATHFROMHTTPURL
+              value: "true"
+            - name: LISTENER_REQUESTINSPECTORS
+              value: "HEADERS_LOGGER"
+      imagePullSecrets:
+        - name: acr-secret

--- a/coa-helm/values.yaml
+++ b/coa-helm/values.yaml
@@ -1,6 +1,7 @@
 ﻿service:
   tesPort: 80
   cromwellPort: 8000
+  relayListenerPort: 80
 
 config:
   resourceGroup: RUNTIME_PARAMETER
@@ -15,12 +16,18 @@ config:
   disableBatchScheduling: false
   dockerInDockerImageName: ""
   usePreemptibleVmsOnly: false
+  relayListenerConnectionString: RUNTIME_PARAMETER
+  relayListenerConnectionName: RUNTIME_PARAMETER
+#  relayListenerSamResourceId:
+#  relayListenerSamUrl:
+  relayListenerTargetHost: "http://cromwell:8000/"
 
 images:
   mysql: mysql:latest
-  cromwell: broadinstitute/cromwell:70
+  cromwell: broadinstitute/cromwell:79
   tes: mcr.microsoft.com/cromwellonazure/tes:2
   triggerservice: mcr.microsoft.com/cromwellonazure/triggerservice:2
+  relaylistener: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:b26c311
 
 containers:
   - configuration


### PR DESCRIPTION
Note: This PR currently merges into `jdg_bt_603_azure` because that branch was the starting point for this work. If that branch merges before this one, I'll update the target branch for this PR.

I've made some updates to the [Helm Installation section of the CaaAoA PoC Setup](https://docs.google.com/document/d/1ux05chycxk6eniNGnS8BuJhSGbyFhJOXvcPpCIh0txE/edit#heading=h.9wudchr0aqht) document to support this.

Note that Swagger UI currently doesn't work, but API calls, such as https://terra-coa.servicebus.windows.net/terra-coa-cromwellapp/engine/v1/version, seem to be fine.