### PR TITLE
BT-565 Enable auth in listener

### DIFF
--- a/coa-helm/templates/relay-listener-deployment.yaml
+++ b/coa-helm/templates/relay-listener-deployment.yaml
@@ -31,6 +31,12 @@ spec:
             - name: LISTENER_TARGETPROPERTIES_REMOVEENTITYPATHFROMHTTPURL
               value: "true"
             - name: LISTENER_REQUESTINSPECTORS
-              value: "HEADERS_LOGGER"
+              value: "SAM_CHECKER"
+            - name: LISTENER_SAMINSPECTORPROPERTIES_SAMURL
+              value: {{ .Values.config.relayListenerSamUrl }}
+            - name: LISTENER_SAMINSPECTORPROPERTIES_SAMRESOURCEID
+              value: {{ .Values.config.relayListenerSamResourceId }}
+            - name: LISTENER_SAMINSPECTORPROPERTIES_SAMRESOURCETYPE
+              value: {{ .Values.config.relayListenerSamResourceType }}
       imagePullSecrets:
         - name: acr-secret

--- a/coa-helm/values.yaml
+++ b/coa-helm/values.yaml
@@ -18,8 +18,9 @@ config:
   usePreemptibleVmsOnly: false
   relayListenerConnectionString: RUNTIME_PARAMETER
   relayListenerConnectionName: RUNTIME_PARAMETER
-#  relayListenerSamResourceId:
-#  relayListenerSamUrl:
+  relayListenerSamResourceId: RUNTIME_PARAMETER
+  relayListenerSamResourceType: "workspace"
+  relayListenerSamUrl: RUNTIME_PARAMETER
   relayListenerTargetHost: "http://cromwell:8000/"
 
 images:
@@ -27,7 +28,7 @@ images:
   cromwell: broadinstitute/cromwell:79
   tes: mcr.microsoft.com/cromwellonazure/tes:2
   triggerservice: mcr.microsoft.com/cromwellonazure/triggerservice:2
-  relaylistener: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:b26c311
+  relaylistener: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:bb18347 # https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/17
 
 containers:
   - configuration

--- a/coa-helm/values.yaml
+++ b/coa-helm/values.yaml
@@ -28,7 +28,7 @@ images:
   cromwell: broadinstitute/cromwell:79
   tes: mcr.microsoft.com/cromwellonazure/tes:2
   triggerservice: mcr.microsoft.com/cromwellonazure/triggerservice:2
-  relaylistener: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:bb18347 # https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/17
+  relaylistener: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:9eb4762
 
 containers:
   - configuration


### PR DESCRIPTION
Builds off of #31 and depends on https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/17. This enables workspace-based authorization in our app's Listener. 

Currently running in our CaaAoA instance. I confirmed that when I passed my token from Terra dev, I could successfully call `https://terra-coa.servicebus.windows.net/terra-coa-cromwellapp/engine/v1/version`. Without the token, or with a differently configured listener, I got a 403.