### PR TITLE
BW-1296 Update CBAS Service and UI images

### DIFF
--- a/cromwell-helm/templates/batch-analysis-ui.yaml
+++ b/cromwell-helm/templates/batch-analysis-ui.yaml
@@ -27,7 +27,7 @@ spec:
                 path: {{ .Values.config.cbasUI.conf_file }}
       containers:
         - name: {{ .Values.batchAnalysisUI.name }}-container
-          image: us.gcr.io/broad-dsp-gcr-public/terra-batch-analysis-ui:cjl_BW-1291
+          image: us.gcr.io/broad-dsp-gcr-public/cbas-ui:0.0.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/cromwell-helm/templates/cbas-deployment.yaml
+++ b/cromwell-helm/templates/cbas-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.cbas.name }}-container
-          image: us.gcr.io/broad-dsp-gcr-public/composite-batch-analysis-service:0.0.8
+          image: us.gcr.io/broad-dsp-gcr-public/cbas:0.0.9
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/terra-batch-libchart/templates/_cbas-api.tpl
+++ b/terra-batch-libchart/templates/_cbas-api.tpl
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.cbas.name }}-container
-          image: us.gcr.io/broad-dsp-gcr-public/composite-batch-analysis-service:0.0.5
+          image: us.gcr.io/broad-dsp-gcr-public/cbas:0.0.9
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/terra-batch-libchart/templates/_cbas-ui.tpl
+++ b/terra-batch-libchart/templates/_cbas-ui.tpl
@@ -25,7 +25,7 @@ spec:
                 path: {{ .Values.config.cbasUI.conf_file }}
       containers:
         - name: {{ .Values.batchAnalysisUI.name }}-container
-          image: us.gcr.io/broad-dsp-gcr-public/terra-batch-analysis-ui:cjl_BW-1291
+          image: us.gcr.io/broad-dsp-gcr-public/cbas-ui:0.0.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
New CBAS Service images:
- DockerHub - [broadinstitute/cbas:0.0.9](https://hub.docker.com/r/broadinstitute/cbas/tags)
- GCR - [us.gcr.io/broad-dsp-gcr-public/cbas:0.0.9](https://console.cloud.google.com/gcr/images/broad-dsp-gcr-public/us/cbas@sha256:1b0afdeb3d0abe2ed50a023144639e3b6901913f3fbe9864441fb72894357bf1/details?project=broad-dsp-gcr-public)

New CBAS UI GCR image: [us.gcr.io/broad-dsp-gcr-public/cbas-ui:0.0.1](https://console.cloud.google.com/gcr/images/broad-dsp-gcr-public/us/cbas-ui@sha256:62bbe55433e2cfb515398e700900a8b1baee304ca46448973270fd1fd1701356/details?project=broad-dsp-gcr-public)

Closes https://broadworkbench.atlassian.net/browse/BW-1296