### PR TITLE
BW-1265 Turn off wasteful Github Pages builds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    # Only the chart auto-update workflow should trigger a pages build. Otherwise, we try to run the build for every commit,
+    # and it always gets cancelled (with an unsightly red X) by the auto-update commit that follows immediately afterward.
+    if: ( startsWith(github.event.head_commit.message, 'Auto update cromwell-helm chart') )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This is 99% a prebuilt template based on the Pages workflow already used under the cover.

The only new lines are
```
    # Only the chart auto-update workflow should trigger a pages build. Otherwise, we try to run the build for every commit,
    # and it always gets cancelled (with an unsightly red X) by the auto-update commit that follows immediately afterward.
    if: ( startsWith(github.event.head_commit.message, 'Auto update cromwell-helm chart') )
```