### PR TITLE
update WDS image to include CORS fixes [AJ-632]

### DIFF
--- a/terra-batch-libchart/values.yaml
+++ b/terra-batch-libchart/values.yaml
@@ -32,7 +32,7 @@ exports:
 
     wds:
       name: wds
-      image: us.gcr.io/broad-dsp-gcr-public/terra-workspace-data-service:e0ba68a
+      image: us.gcr.io/broad-dsp-gcr-public/terra-workspace-data-service:f25cf44
       conf_dir: /etc/conf
       conf_file: wds.yaml
 


### PR DESCRIPTION
Updates WDS image to `f25cf44`, which includes CORS fixes from https://github.com/DataBiosphere/terra-workspace-data-service/pull/94