### PR TITLE
[WM-1429] Update Cromwell version in terra-batch-libchart

### DIFF
--- a/terra-batch-libchart/values.yaml
+++ b/terra-batch-libchart/values.yaml
@@ -2,7 +2,7 @@ exports:
   common:
     cromwell:
       name: coa-cromwell-svc
-      image: broadinstitute/cromwell:85-d602cef-SNAP
+      image: broadinstitute/cromwell:85-f64b2c4
       port: 8000
 
     proxy:


### PR DESCRIPTION
This updates Cromwell version to latest image as the previous SNAP version doesn't exist.