### PR TITLE
TOAZ-243: Also publish Cromwell on Azure to github pages

### DIFF
--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -40,6 +40,9 @@ jobs:
           helm dependency update cromwell-helm/
           helm package cromwell-helm/
           mv cromwell-${NEXT_VERSION_GCP}.tgz charts/cromwell-${NEXT_VERSION_GCP}.tgz
+          helm dependency update coa-helm/
+          helm package coa-helm/
+          mv cromwell-on-azure-${NEXT_VERSION_COA}.tgz charts/cromwell-on-azure-${NEXT_VERSION_COA}.tgz
           helm repo index --url https://broadinstitute.github.io/cromwhelm/charts/ charts
 
       - name: Push changes to GitHub


### PR DESCRIPTION
It looks like this repo's actions _is_ bumping the `coa-helm` chart version, but not publishing it to GitHub pages. Hoping this does the trick.

We are also not yet auto-updating Leo with `coa-helm` version upgrades, but I'm thinking we can punt that till later as the Azure stuff is still a bit in flux.