### PR TITLE
[WM-1471] add automerge workflow to Cromwhelm

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,28 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "broadinstitute/automerge-action@v0.12.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "automerge,!work in progress"


### PR DESCRIPTION
this workflow should cause PRs with an "automerge" label (and _without_ a "work in progress" label) to be automatically merged into this repository.

this is really part of an effort to configure this functionality in Leonardo, but we'd like to test it here first (due to lower consequences for failure).

(note that automerged PRs should not trigger other workflows -- in other words, we should not expect to see the Leo PR workflow run as a direct consequence of an automerged PR)

although this is a test, we may find this functionality useful in our repo as well.