### PR TITLE
TOAZ-242 Add samAction parameter to listener deployment

### DIFF
--- a/coa-helm/templates/relay-listener-deployment.yaml
+++ b/coa-helm/templates/relay-listener-deployment.yaml
@@ -39,5 +39,7 @@ spec:
               value: {{ .Values.relaylistener.samResourceId }}
             - name: LISTENER_SAMINSPECTORPROPERTIES_SAMRESOURCETYPE
               value: {{ .Values.relaylistener.samResourceType }}
+            - name: LISTENER_SAMINSPECTORPROPERTIES_SAMACTION
+              value: {{ .Values.relaylistener.samAction }}
       imagePullSecrets:
         - name: acr-secret

--- a/coa-helm/values.yaml
+++ b/coa-helm/values.yaml
@@ -17,7 +17,7 @@ tes:
   port: 80
 
 relaylistener:
-  image: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:0f971ce
+  image: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:5548660
   port: 8080
   connectionString: RUNTIME_PARAMETER
   connectionName: RUNTIME_PARAMETER

--- a/coa-helm/values.yaml
+++ b/coa-helm/values.yaml
@@ -17,7 +17,7 @@ tes:
   port: 80
 
 relaylistener:
-  image: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:9eb4762
+  image: terradevacrpublic.azurecr.io/terra-azure-relay-listeners:0f971ce
   port: 8080
   connectionString: RUNTIME_PARAMETER
   connectionName: RUNTIME_PARAMETER

--- a/coa-helm/values.yaml
+++ b/coa-helm/values.yaml
@@ -26,6 +26,7 @@ relaylistener:
   samResourceId: RUNTIME_PARAMETER
   samResourceType: "workspace"
   samUrl: RUNTIME_PARAMETER
+  samAction: "write"
 
 persistence:
   postgresPvcSize: 10Gi


### PR DESCRIPTION
Provides helm support for new `samAction` parameter added here: https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/22/

Leo needs to configure the sam action differently depending on whether it's a runtime or kubernetes-app.

Tested this locally using Leo `AKSManualTest`.