### PR TITLE
WM-1526: Increase workflow start rate

### DIFF
--- a/coa-helm/templates/cromwell.yaml
+++ b/coa-helm/templates/cromwell.yaml
@@ -58,6 +58,20 @@ data:
     }
 
     system {
+      max-concurrent-workflows = 10000
+      new-workflow-poll-rate = 10
+      max-workflow-launch-count = 30
+      max-scatter-width-per-scatter = 35000
+      total-max-jobs-per-root-workflow = 200000
+      job-rate-control {
+        jobs = 20
+        per = 5 seconds
+      }
+      job-restart-check-rate-control {
+        jobs = 30
+        per = 1 seconds
+      }
+
       input-read-limits {
         lines = 1000000
       }

--- a/cromwell-helm/templates/cromwell.yaml
+++ b/cromwell-helm/templates/cromwell.yaml
@@ -53,7 +53,21 @@ spec:
 data:
   {{ .Values.cromwell.config.file }}: |-
     include required(classpath("application"))
-
+    system {
+      max-concurrent-workflows = 10000
+      new-workflow-poll-rate = 10
+      max-workflow-launch-count = 30
+      max-scatter-width-per-scatter = 35000
+      total-max-jobs-per-root-workflow = 200000
+      job-rate-control {
+        jobs = 20
+        per = 5 seconds
+      }
+      job-restart-check-rate-control {
+        jobs = 30
+        per = 1 seconds
+      }
+    }
     google {
 
       application-name = "cromwell"


### PR DESCRIPTION
Includes workflow start rates pre- https://github.com/broadinstitute/firecloud-develop/pull/2730, since that change was made for distributional, rather than start-rate, reasons.