### PR TITLE
[AJ-696] remove check against auto-updates

### DIFF
--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   update-and-publish:
-    if: ( !startsWith(github.event.head_commit.message, 'Auto update cromwell-helm chart version') )
     name: Update and publish new cromwell-helm chart
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
For our future selves: the Jira ID is "AJ-696" because it is related to a discussion between David, Michael, and Chris releasing a new version of WDS to Leonardo through the cromwhelm charts. The newly-implemented automerge functionality in Leonardo requires that a Jira ID representing the change is present in the commit message.