### PR TITLE
[AJ-676 follow up] Use nindent instead of indent to avoid yaml merge issues

### DIFF
--- a/coa-helm/templates/cbas-api.yaml
+++ b/coa-helm/templates/cbas-api.yaml
@@ -5,7 +5,7 @@ spec:
   template:
     metadata:
       labels:
-    {{ include "coa-helm.labels" $ | indent 8 }}
+    {{ include "coa-helm.labels" $ | nindent 8 }}
 {{ end }}
 
 ---

--- a/coa-helm/templates/cbas-ui.yaml
+++ b/coa-helm/templates/cbas-ui.yaml
@@ -4,7 +4,7 @@ spec:
   template:
     metadata:
       labels:
-    {{ include "coa-helm.labels" $ | indent 8 }}
+    {{ include "coa-helm.labels" $ | nindent 8 }}
 {{ end }}
 
 ---

--- a/coa-helm/templates/cromwell.yaml
+++ b/coa-helm/templates/cromwell.yaml
@@ -4,7 +4,7 @@ spec:
   template:
     metadata:
       labels:
-    {{ include "coa-helm.labels" $ | indent 8 }}
+    {{ include "coa-helm.labels" $ | nindent 8 }}
     spec:
       containers:
         - args:

--- a/coa-helm/templates/wds.yaml
+++ b/coa-helm/templates/wds.yaml
@@ -4,7 +4,7 @@ spec:
   template:
     metadata:
       labels:
-    {{ include "coa-helm.labels" $ | indent 8 }}
+    {{ include "coa-helm.labels" $ | nindent 8 }}
 {{ end }}
 
 ---


### PR DESCRIPTION
Error:
```
The command 'helm installChart' failed with result unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment): unknown field "Error" in io.k8s.api.apps.v1.Deployment"
```

This seems to fix it, I wish I had a better understanding as to why. All `nindent` does compared to `indent` is prepend a newline. Maybe a consequence of the yaml merge logic in https://github.com/broadinstitute/cromwhelm/blob/main/terra-batch-libchart/templates/_util.yaml? I do notice that the libchart uses `nindent` ([example](https://github.com/broadinstitute/cromwhelm/blob/main/terra-batch-libchart/templates/_cbas-ui.tpl#L16)).

### Before fix:
There is an error in templating, and the `aadpodidbinding`, `leoAppName`, `workspaceId` pod labels are nowhere to be found:
```
# Source: cromwell-on-azure/templates/cbas-ui.yaml
Error: 'error converting YAML to JSON: yaml: line 6: did not find expected key'
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cromwell-on-azure
    helm.sh/chart: cromwell-on-azure-0.2.178
  name: release-name-cromwell-on-azure-cbas-ui-depl
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/component: cbas-ui
  template:
    metadata:
      labels:
        app.kubernetes.io/component: cbas-ui
    spec:
      containers:
      - image: us.gcr.io/broad-dsp-gcr-public/cbas-ui:0.0.21
        imagePullPolicy: Always
        name: cbas-ui-container
        ports:
        - containerPort: 8080
        volumeMounts:
        - mountPath: /usr/share/nginx/html/config.json
          name: release-name-cromwell-on-azure-cbas-ui-config
          subPath: config.json
      hostname: cbas-ui
      volumes:
      - configMap:
          items:
          - key: config.json
            path: config.json
          name: release-name-cromwell-on-azure-cbas-ui-config
        name: release-name-cromwell-on-azure-cbas-ui-config
```

### After fix:
No errors, and the 3 pod labels are there:
```
# Source: cromwell-on-azure/templates/cbas-ui.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cromwell-on-azure
    helm.sh/chart: cromwell-on-azure-0.2.178
  name: release-name-cromwell-on-azure-cbas-ui-depl
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/component: cbas-ui
  template:
    metadata:
      labels:
        aadpodidbinding: RUNTIME_PARAMETER
        app.kubernetes.io/component: cbas-ui
        leoAppName: RUNTIME_PARAMETER
        workspaceId: RUNTIME_PARAMETER
    spec:
      containers:
      - image: us.gcr.io/broad-dsp-gcr-public/cbas-ui:0.0.21
        imagePullPolicy: Always
        name: cbas-ui-container
        ports:
        - containerPort: 8080
        volumeMounts:
        - mountPath: /usr/share/nginx/html/config.json
          name: release-name-cromwell-on-azure-cbas-ui-config
          subPath: config.json
      hostname: cbas-ui
      volumes:
      - configMap:
          items:
          - key: config.json
            path: config.json
          name: release-name-cromwell-on-azure-cbas-ui-config
        name: release-name-cromwell-on-azure-cbas-ui-config
```