### PR TITLE
AJ-717: Temporarily disable TES Deployment in coa-helm chart

### DIFF
--- a/coa-helm/templates/tes.yaml
+++ b/coa-helm/templates/tes.yaml
@@ -72,3 +72,4 @@
 #    io.kompose.service: tes
 #status:
 #  loadBalancer: {}
+#


### PR DESCRIPTION
Trivial change from https://github.com/broadinstitute/cromwhelm/pull/168 in order to invoke Github Actions correctly (needs a JIRA ticket ID in name)

This PR temporarily disables TES -- since TES is not functional yet, this removes any problems that TES might cause within an AKS cluster

Eventually, TES will be re-integrated though