### PR TITLE
AJ-822 add resource limits

### DIFF
--- a/coa-helm/Chart.yaml
+++ b/coa-helm/Chart.yaml
@@ -1,6 +1,6 @@
 name: cromwell-on-azure
 description: A cromwell deployment designed to run on Azure with Postgres. 
-version: 0.2.188
+version: 0.2.187
 apiVersion: v2
 dependencies:
   - name: terra-batch-libchart

--- a/coa-helm/Chart.yaml
+++ b/coa-helm/Chart.yaml
@@ -1,6 +1,6 @@
 name: cromwell-on-azure
 description: A cromwell deployment designed to run on Azure with Postgres. 
-version: 0.2.187
+version: 0.2.188
 apiVersion: v2
 dependencies:
   - name: terra-batch-libchart

--- a/coa-helm/templates/cromwell.yaml
+++ b/coa-helm/templates/cromwell.yaml
@@ -18,7 +18,13 @@ spec:
           tty: true
           ports:
             - containerPort: {{ .Values.cromwell.port }}
-          resources: {}
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "50m"
+            limits:
+              memory: "1024Mi"
+              cpu: "200m"
           volumeMounts:
             - mountPath: /cromwell-tmp
               name: cromwell-tmp-claim

--- a/terra-batch-libchart/templates/_cbas-api.tpl
+++ b/terra-batch-libchart/templates/_cbas-api.tpl
@@ -21,6 +21,13 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "50m"
+            limits:
+              memory: "1024Mi"
+              cpu: "200m"
           volumeMounts:
             - name: {{ include "app.fullname" . }}-cbas-config
               mountPath: {{ .Values.cbas.conf_dir }}/{{ .Values.cbas.conf_file }}

--- a/terra-batch-libchart/templates/_wds.tpl
+++ b/terra-batch-libchart/templates/_wds.tpl
@@ -21,6 +21,13 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
+          resources:
+            requests:
+                memory: "768Mi"
+                cpu: "50m"
+            limits:
+                memory: "1536Mi"
+                cpu: "200m"
           volumeMounts:
             - name: {{ include "app.fullname" . }}-wds-config
               mountPath: {{ .Values.wds.conf_dir }}/{{ .Values.wds.conf_file }}

--- a/terra-batch-libchart/templates/_wds.tpl
+++ b/terra-batch-libchart/templates/_wds.tpl
@@ -23,10 +23,10 @@ spec:
             - containerPort: 8080
           resources:
             requests:
-                memory: "768Mi"
+                memory: "256Mi"
                 cpu: "50m"
             limits:
-                memory: "1536Mi"
+                memory: "1024Mi"
                 cpu: "200m"
           volumeMounts:
             - name: {{ include "app.fullname" . }}-wds-config


### PR DESCRIPTION
See [AJ-822](https://broadworkbench.atlassian.net/browse/AJ-822)
Add initial requests and limits for CPU and memory for the CBAS, Cromwell, and WDS containers.  I welcome comments and suggestions on what are sensible numbers to use.  In most cases I've seen the numbers I have here are extremely conservative - most cpu values I've seen for containers are <~100m, memory <~256Mi - but I have seen containers that leap up to 600m+ cpu and 600Mi+ memory - unclear if we can expect those values to be necessary in normal usage or if something pathological was happening.

[AJ-822]: https://broadworkbench.atlassian.net/browse/AJ-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ