### PR TITLE
AJ-827: increase client body size to 50M for WDS

### DIFF
--- a/terra-batch-libchart/templates/_reverse-proxy.tpl
+++ b/terra-batch-libchart/templates/_reverse-proxy.tpl
@@ -104,6 +104,7 @@ data:
           proxy_pass http://{{ include "app.fullname" . }}-cromwell-svc:8000/;
         }
         location /wds/ {
+          client_max_body_size 50M;
           proxy_pass http://{{ include "app.fullname" . }}-wds-svc:8080/;
         }
 


### PR DESCRIPTION
Default setting for `client_max_body_size` in nginx is 1M, apparently.

This restricts the size of TSV uploads for WDS. In this PR, I increase that limit to 50M.

We may want to pipe this through values at some point instead of hardcoding it?