### PR TITLE
[IA-3656] update deprecated k8 networking api version to v1

### DIFF
--- a/cromwell-helm/templates/ingress.yaml
+++ b/cromwell-helm/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "app.fullname" . -}}
-apiVersion:  networking.k8s.io/v1beta1
+apiVersion:  networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Relevant context can be found here: https://broadinstitute.slack.com/archives/C1EH66VCM/p1675346412119639

But the TL;DR is that the `networking.k8s.io/v1beta1` has been deprecated after k8s 1.21 and needs to be updated.