### PR TITLE
[IA-4021] fix the ingress path syntax for new v1 endpoint

### DIFF
--- a/cromwell-helm/templates/ingress.yaml
+++ b/cromwell-helm/templates/ingress.yaml
@@ -28,9 +28,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}-reverse-proxy-service
-              servicePort: {{ $.Values.proxy.port }}
+              service:
+                name: {{ $fullName }}-reverse-proxy-service
+                port:
+                  number: {{ $.Values.proxy.port }}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Turns out that there was a few breaking changes when moving from the v1beta to the V1 endpoint:
https://github.com/kubernetes/kubernetes/pull/89778
The pathType cannot be defaulted anymore, it looks like `Prefix` would be the correct option - https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
JIRA ticket: https://broadworkbench.atlassian.net/browse/IA-4021