### PR TITLE
Change persistent volume accessMode to ReadWriteOnce for cromwell-gcp

### DIFF
--- a/cromwell-helm/values.yaml
+++ b/cromwell-helm/values.yaml
@@ -30,7 +30,7 @@ persistence:
   enabled: true
   storageClass: "manual"
   size: 10G
-  accessMode: ReadOnlyMany
+  accessMode: ReadWriteOnce
   mountPath: "/data"
   gcePersistentDisk: "SUPPLIED BY LEO"
 


### PR DESCRIPTION
Haven't tested yet, will test through Leo.

See https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/928

This PV _should_ be read-write as it supports postgres and is mapped 1-1 with a user-owned persistent disk. A theory is this setting was always incorrect, but just started to fail in the GKE 1.24 upgrade.