### PR TITLE
WM-1681: Access log for requests through proxy

### DIFF
--- a/terra-batch-libchart/templates/_reverse-proxy.tpl
+++ b/terra-batch-libchart/templates/_reverse-proxy.tpl
@@ -80,6 +80,7 @@ data:
     }
     http {
       server {
+        access_log /dev/stdout combined;
         listen 8000;
 
         # Reference to ngingx's local content


### PR DESCRIPTION
All requests through the proxy will now generate access logs along the lines of:

```
10.244.11.17 - - [15/Feb/2023:15:02:56 +0000] "GET /cbas/api/batch/v1/methods?method_id=00000000-0000-0000-0000-000000000008 HTTP/1.1" 200 616 "https://lzf07312d05014dcfc2a6d8244c0f9b166a3801f44ec2b003d.servicebus.windows.net/wds-410a5a2e-d1dd-4327-add4-73e0e6248938/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"
10.244.11.17 - - [15/Feb/2023:15:04:59 +0000] "GET /cbas/status HTTP/1.1" 200 64 "-" "http4s-blaze/1.0.0-M35"
10.244.11.17 - - [15/Feb/2023:15:11:36 +0000] "GET /cbas/status HTTP/1.1" 200 64 "-" "http4s-blaze/1.0.0-M35"
```