### PR TITLE
WX-952 Remove obsolete Cromwell version

### DIFF
--- a/cromwell-helm/Chart.yaml
+++ b/cromwell-helm/Chart.yaml
@@ -17,14 +17,6 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.2.202
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-
-# Keep this format stable for automatic version bumps from https://github.com/broadinstitute/cromwell/pull/6739
-appVersion: "85-e844915"
-
 dependencies:
   - name: terra-batch-libchart
     version: 0.0.2


### PR DESCRIPTION
This value was no longer used anywhere. Confirmed that I can still `helm template cromwell-helm` without it.

See also https://github.com/broadinstitute/cromwell/pull/7014