### PR TITLE
[RW-8626] Enable Cromwell call caching for CaaA on GCP

### DIFF
--- a/cromwell-helm/templates/cromwell.yaml
+++ b/cromwell-helm/templates/cromwell.yaml
@@ -74,6 +74,12 @@ data:
         per = 1 seconds
       }
     }
+    
+    call-caching {
+      enabled = true
+      invalidate-bad-cache-results = true
+    }
+
     google {
 
       application-name = "cromwell"


### PR DESCRIPTION
AoU needs to enable call caching and it is must have for AoU launching CaaA for GCP. 
I see we already create a postgres DB in that cluster for Cromwell, seems this is the only thing left. 
