### PR TITLE
AJ-764: Use appropriate env var naming per Azure docs

### DIFF
--- a/terra-batch-libchart/templates/_wds.tpl
+++ b/terra-batch-libchart/templates/_wds.tpl
@@ -33,7 +33,7 @@ spec:
               mountPath: {{ .Values.wds.conf_dir }}/{{ .Values.wds.conf_file }}
               subPath: {{ .Values.wds.conf_file }}
           env:
-            - name: AZURE_APPLICATION_INSIGHTS_CONNECTION_STRING
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
               value: {{ .Values.config.applicationInsightsConnectionString }}
             - name: SPRING_CONFIG_ADDITIONAL-LOCATION
               value: {{ .Values.wds.conf_dir }}/{{ .Values.wds.conf_file }}


### PR DESCRIPTION
Relates to https://broadworkbench.atlassian.net/browse/AJ-764

Need to use `APPLICATIONINSIGHTS_CONNECTION_STRING` per docs here https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable?tabs=java