### PR TITLE
make clientId available to wds

### DIFF
--- a/terra-batch-libchart/templates/_wds.tpl
+++ b/terra-batch-libchart/templates/_wds.tpl
@@ -57,6 +57,8 @@ spec:
               value: "{{ .Values.config.resourceGroup }}"
             - name: RELEASE_NAME
               value: {{ include "app.fullname" . }}
+            - name: CLIENT_ID
+              value: "{{ .Values.identity.clientId }}"
 
       volumes:
         - name: {{ include "app.fullname" . }}-wds-config


### PR DESCRIPTION
[AJ-897](https://broadworkbench.atlassian.net/browse/AJ-897) adds a sam permission check to WDS through the azure managed identity, which needs the clientId to obtain an access token.