### PR TITLE
WX-987 Use modern Akka http connection pool

### DIFF
--- a/coa-helm/templates/cromwell.yaml
+++ b/coa-helm/templates/cromwell.yaml
@@ -67,8 +67,6 @@ data:
   cromwell-application.conf: |-
     include required(classpath("application"))
 
-    akka.http.host-connection-pool.pool-implementation = legacy
-
     call-caching {
       enabled = false
     }


### PR DESCRIPTION
This silences a warning Akka has been printing and is consistent with how we run Cromwell in other contexts.