### PR TITLE
WX-1631 Disable CBAS in GCP Cromwell chart

### DIFF
--- a/cromwell-helm/values.yaml
+++ b/cromwell-helm/values.yaml
@@ -43,5 +43,8 @@ cromwell:
     dir: /etc/conf
     file: papi.conf
 
+cbas:
+  enabled: false
+
 identity:
   clientId: RUNTIME_PARAMETER


### PR DESCRIPTION
This will prevent NGINX config from being told to forward some things to CBAS, which does not exist. I confirmed that telling NGINX to forward requests to a nonexistent address causes crashes like the ones we observed.