### PR TITLE
[AN-514] Have Cromwell App follow the `latest` tag

### DIFF
--- a/cromwell-helm/Chart.yaml
+++ b/cromwell-helm/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.556
+version: 0.2.557
 
 dependencies:
   - name: terra-batch-libchart

--- a/terra-batch-libchart/values.yaml
+++ b/terra-batch-libchart/values.yaml
@@ -2,6 +2,7 @@ exports:
   common:
     cromwell:
       name: coa-cromwell-svc
+      # Note: The cromwell `latest` tag follows the most recent numerical community release, not develop
       image: broadinstitute/cromwell:latest
       port: 8000
       enabled: true

--- a/terra-batch-libchart/values.yaml
+++ b/terra-batch-libchart/values.yaml
@@ -2,7 +2,7 @@ exports:
   common:
     cromwell:
       name: coa-cromwell-svc
-      image: broadinstitute/cromwell:89-561bbf4
+      image: broadinstitute/cromwell:latest
       port: 8000
       enabled: true
 


### PR DESCRIPTION
As of https://github.com/broadinstitute/cromwell/pull/7734 the `Latest` for cromwell images follows the numerical community releases (rather than develop)

This PR sets the cromwell app to follow these stable releases