### PR TITLE
[AN-782] Push new cromwhelm chart release

### DIFF
--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -9,7 +9,7 @@ jobs:
     name: Update and publish new cromwell-helm chart
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure that a Jira ID is present in the commit message #requires no spaces!
+      - name: Ensure that a Jira ID is present in the commit message #requires no extra spaces!
         id: ensure-jira-id
         run: |
           JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')

--- a/.github/workflows/update-and-publish-helm-chart.yml
+++ b/.github/workflows/update-and-publish-helm-chart.yml
@@ -9,7 +9,7 @@ jobs:
     name: Update and publish new cromwell-helm chart
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure that a Jira ID is present in the commit message
+      - name: Ensure that a Jira ID is present in the commit message #requires no spaces!
         id: ensure-jira-id
         run: |
           JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')


### PR DESCRIPTION
Previous commit to remove PAPI references had a mis-configured jira ID and didn't release properly, putting out a dummy release to trigger a new run with a clean ID